### PR TITLE
新增两个Frame的方法重载&其他一些小更改

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         continue-on-error: true
         run: |
           dotnet build .\source\iNKORE.UI.WPF.Modern
-          dotnet build .\source\iNKORE.UI.WPF.Modern.Gallery
+          dotnet publish .\source\iNKORE.UI.WPF.Modern.Gallery -r win-x64 -f net6.0-windows10.0.18362.0 --no-self-contained -p:PublishSingleFile=true -p:IncludeContentInSingleFile=true
         # dotnet pack .\source\iNKORE.UI.WPF.Modern.Controls --configuration Release -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
       - name: Upload binary libraries of iNKORE.UI.WPF.Modern.Controls
@@ -33,8 +33,8 @@ jobs:
           name: iNKORE.UI.WPF.Modern.Controls dlls
           path: .\source\iNKORE.UI.WPF.Modern.Controls\bin\Debug
 
-      - name: Upload sample apps
+      - name: Upload Gallery apps
         uses: actions/upload-artifact@v3
         with:
-          name: iNKORE.UI.WPF.Modern.Gallery files
-          path: .\source\iNKORE.UI.WPF.Modern.Gallery\bin\Debug
+          name: iNKORE.UI.WPF.Modern.Gallery
+          path: .\source\iNKORE.UI.WPF.Modern.Gallery\bin\Debug\net6.0-windows10.0.18362.0\win-x64\publish

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
   <a href="#"><img src="https://img.shields.io/github/v/release/iNKOREStudios/UI.WPF.Modern?color=%4CF4A8B4" alt="Latest Version"></a>
   <a href="#"><img src="https://img.shields.io/github/release-date/iNKOREStudios/UI.WPF.Modern?color=%23b0a3e8" alt="Release Date"></a>
   <a href="https://github.com/iNKOREStudios/UI.WPF.Modern/commits/"><img src="https://img.shields.io/github/commit-activity/m/iNKOREStudios/UI.WPF.Modern" alt="Commit Activity"></a>
+  <a href="https://www.nuget.org/packages/iNKORE.UI.WPF.Modern"><img src="https://img.shields.io/nuget/v/iNKORE.UI.WPF.Modern?color=blue&logo=nuget" alt="Nuget latest version"></a>
+  <a href="https://www.nuget.org/packages/iNKORE.UI.WPF.Modern"><img src="https://img.shields.io/nuget/dt/iNKORE.UI.WPF.Modern?color=blue&logo=nuget" alt="Nuget download conut"></a>
 </p>
 
 <p align="center">

--- a/source/iNKORE.UI.WPF.Modern.Controls/iNKORE.UI.WPF.Modern.Controls.csproj
+++ b/source/iNKORE.UI.WPF.Modern.Controls/iNKORE.UI.WPF.Modern.Controls.csproj
@@ -15,6 +15,7 @@
 		<AssemblyOriginatorKeyFile>..\..\assets\misc\iNKORE.Pulic.snk</AssemblyOriginatorKeyFile>
 		<RootNamespace>iNKORE.UI.WPF.Modern</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 
 	<!--<PropertyGroup>

--- a/source/iNKORE.UI.WPF.Modern.Controls/iNKORE.UI.WPF.Modern.Controls.csproj
+++ b/source/iNKORE.UI.WPF.Modern.Controls/iNKORE.UI.WPF.Modern.Controls.csproj
@@ -14,6 +14,7 @@
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\..\assets\misc\iNKORE.Pulic.snk</AssemblyOriginatorKeyFile>
 		<RootNamespace>iNKORE.UI.WPF.Modern</RootNamespace>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<!--<PropertyGroup>

--- a/source/iNKORE.UI.WPF.Modern.Gallery/ControlPages/PageTransitionPage.xaml.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/ControlPages/PageTransitionPage.xaml.cs
@@ -26,12 +26,12 @@ namespace iNKORE.UI.WPF.Modern.Gallery.ControlPages
             if (_transitionInfo == null)
             {
                 // Default behavior, no transition set or used.
-                ContentFrame.Navigate(pageToNavigateTo, null);
+                ContentFrame.Navigate(sourcePageType: pageToNavigateTo, null);
             }
             else
             {
                 // Explicit transition info used.
-                ContentFrame.Navigate(pageToNavigateTo, null, _transitionInfo);
+                ContentFrame.Navigate(sourcePageType: pageToNavigateTo, null, _transitionInfo);
             }
         }
 

--- a/source/iNKORE.UI.WPF.Modern/Common/AnimatedIconSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Common/AnimatedIconSource.cs
@@ -1,18 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System.Windows;
-*/
 using iNKORE.UI.WPF.Modern.Controls;
 using System.Windows;
-using System.Windows.Media;
 
 namespace iNKORE.UI.WPF.Modern.Common
 {

--- a/source/iNKORE.UI.WPF.Modern/Common/BitmapIconSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Common/BitmapIconSource.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System;
-*/
 using iNKORE.UI.WPF.Modern.Controls;
 using System;
 using System.Windows;

--- a/source/iNKORE.UI.WPF.Modern/Common/FontIconSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Common/FontIconSource.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System.Windows;
-*/
 using iNKORE.UI.WPF.Modern.Controls;
 using System.Windows;
 using System.Windows.Media;

--- a/source/iNKORE.UI.WPF.Modern/Common/IconSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Common/IconSource.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System.Windows;
-*/
 using System.Windows;
 using System.Windows.Media;
 using iNKORE.UI.WPF.Modern.Controls;

--- a/source/iNKORE.UI.WPF.Modern/Common/ImageIconSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Common/ImageIconSource.cs
@@ -1,13 +1,4 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System;
-*/
-using iNKORE.UI.WPF.Modern.Controls;
+﻿using iNKORE.UI.WPF.Modern.Controls;
 using System;
 using System.Windows;
 using System.Windows.Controls;

--- a/source/iNKORE.UI.WPF.Modern/Common/PathIconSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Common/PathIconSource.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System.Windows;
-*/
 using iNKORE.UI.WPF.Modern.Controls;
 using System.Windows;
 using System.Windows.Media;

--- a/source/iNKORE.UI.WPF.Modern/Common/SymbolIconSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Common/SymbolIconSource.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System.Windows;
-*/
 using iNKORE.UI.WPF.Modern.Controls;
 using System.Windows;
 

--- a/source/iNKORE.UI.WPF.Modern/Controls/AcrylicElement.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/AcrylicElement.cs
@@ -6,20 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Media;
-在此之后:
-using System.Windows.Media;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.Acrylic;
-*/
 using System.Windows.Media;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/AcrylicPanel.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/AcrylicPanel.cs
@@ -1,17 +1,5 @@
 ﻿// Ported from https://github.com/sourcechord/FluentWPF/blob/master/FluentWPF/AcrylicPanel.cs
 
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Controls.Primitives;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern.Controls.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.Acrylic;
-using iNKORE.UI.WPF.Modern.Controls.Primitives;
-*/
 using iNKORE.UI.WPF.Modern.Controls.Primitives;
 using System;
 using System.Collections.Generic;

--- a/source/iNKORE.UI.WPF.Modern/Controls/AnimatedBackVisualSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/AnimatedBackVisualSource.cs
@@ -3,20 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using System.Windows;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.AnimatedVisuals;
-*/
 using System.Windows;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/AnimatedIcon.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/AnimatedIcon.cs
@@ -1,26 +1,4 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System;
-*/
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Common;
-using iNKORE.UI.WPF.Modern.Controls.AnimatedVisuals;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern.Common;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.AnimatedVisuals;
-*/
-using iNKORE.UI.WPF.Modern.Common;
+﻿using iNKORE.UI.WPF.Modern.Common;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/source/iNKORE.UI.WPF.Modern/Controls/AnimatedVisualSource.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/AnimatedVisualSource.cs
@@ -1,19 +1,4 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Common;
-using System;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern.Common;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.AnimatedVisuals;
-using System;
-*/
-using iNKORE.UI.WPF.Modern.Common;
+﻿using iNKORE.UI.WPF.Modern.Common;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/source/iNKORE.UI.WPF.Modern/Controls/BitmapIcon.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/BitmapIcon.cs
@@ -1,31 +1,8 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System;
-*/
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Shapes;
-在此之后:
-using System.Windows.Shapes;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-*/
 using System.Windows.Shapes;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/FontIcon.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/FontIcon.cs
@@ -1,30 +1,7 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.ComponentModel;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System.ComponentModel;
-*/
-using iNKORE.UI.WPF.Modern.Common;
+﻿using iNKORE.UI.WPF.Modern.Common;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Media;
-在此之后:
-using System.Windows.Media;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-*/
 using System.Windows.Media;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/Frame.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Frame.cs
@@ -1,17 +1,4 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Helpers;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.Navigation;
-using iNKORE.UI.WPF.Modern.Helpers;
-*/
-using iNKORE.UI.WPF.Modern.Helpers;
+﻿using iNKORE.UI.WPF.Modern.Helpers;
 using iNKORE.UI.WPF.Modern.Media.Animation;
 using System;
 using System.Collections.Specialized;
@@ -276,6 +263,32 @@ namespace iNKORE.UI.WPF.Modern.Controls
         {
             _transitionInfoOverride = infoOverride;
             return Navigate(Activator.CreateInstance(sourcePageType), parameter);
+        }
+
+        /// <summary>
+        /// Navigates asynchronously to content that is contained by an object.
+        /// </summary>
+        /// <param name="content">An System.Object that contains the content to navigate to.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
+        /// <returns>true if navigation is not canceled; otherwise, false.</returns>
+        public bool Navigate(object content, NavigationTransitionInfo infoOverride)
+        {
+            _transitionInfoOverride = infoOverride;
+            return Navigate(content);
+        }
+
+        /// <summary>
+        /// Navigates asynchronously to content that is contained by an object, and passes
+        /// an object that contains data to be used for processing during navigation.
+        /// </summary>
+        /// <param name="content">An System.Object that contains the content to navigate to.</param>
+        /// <param name="extraData">A System.Object that contains data to be used for processing during navigation.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
+        /// <returns>true if navigation is not canceled; otherwise, false.</returns>
+        public bool Navigate(object content, object extraData, NavigationTransitionInfo infoOverride)
+        {
+            _transitionInfoOverride = infoOverride;
+            return Navigate(content, extraData);
         }
 
         /// <summary>

--- a/source/iNKORE.UI.WPF.Modern/Controls/IconElement.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/IconElement.cs
@@ -1,37 +1,9 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System;
-*/
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Media;
-在此之后:
-using System.Windows.Media;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-*/
 using System.Windows.Media;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/ImageIcon.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/ImageIcon.cs
@@ -1,31 +1,8 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System;
-*/
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Shapes;
-在此之后:
-using System.Windows.Shapes;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-*/
 using System.Windows.Shapes;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/Page.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Page.cs
@@ -1,20 +1,6 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Media;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Navigation;
-在此之后:
-using System.Windows.Navigation;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.Navigation;
-*/
 using System.Windows.Navigation;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/PathIcon.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/PathIcon.cs
@@ -1,28 +1,5 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System.Windows;
-*/
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Media;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Shapes;
-在此之后:
-using System.Windows.Shapes;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-*/
 using System.Windows.Shapes;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/Primitives/BackRequestedEventArgs.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Primitives/BackRequestedEventArgs.cs
@@ -1,12 +1,4 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-using System.Windows;
-*/
-using System.Windows;
+﻿using System.Windows;
 
 namespace iNKORE.UI.WPF.Modern.Controls.Primitives
 {

--- a/source/iNKORE.UI.WPF.Modern/Controls/Primitives/CoreApplicationViewTitleBar.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Primitives/CoreApplicationViewTitleBar.cs
@@ -1,52 +1,7 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-using System.Windows;
-*/
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Common;
-using iNKORE.UI.WPF.Modern.Controls.TitleBar.TitleBar;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Common;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.TitleBar;
-using iNKORE.UI.TitleBar.TitleBar;
-*/
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Common;
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Common;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.TitleBar;
-*/
-using iNKORE.UI.WPF.Modern.Common;
+﻿using iNKORE.UI.WPF.Modern.Common;
 using System.Windows;
 using System.Windows.Data;
 
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-namespace iNKORE.UI.WPF.Modern.Controls.TitleBar
-在此之后:
-namespace iNKORE.UI.WPF.Modern.Controls.TitleBar.TitleBar
-*/
 namespace iNKORE.UI.WPF.Modern.Controls.Primitives
 {
     internal sealed class CoreApplicationViewTitleBar

--- a/source/iNKORE.UI.WPF.Modern/Controls/Primitives/TitleBar.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Primitives/TitleBar.cs
@@ -1,35 +1,6 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Controls.Primitives;
-using System;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.Primitives;
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-using System;
-*/
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Input;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Media;
-在此之后:
-using System.Windows.Media;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-*/
 using System.Windows.Media;
 
 namespace iNKORE.UI.WPF.Modern.Controls.Primitives

--- a/source/iNKORE.UI.WPF.Modern/Controls/Primitives/TitleBarButton.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Primitives/TitleBarButton.cs
@@ -1,19 +1,5 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Media;
-在此之后:
-using System.Windows.Media;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-*/
 using System.Windows.Media;
 
 namespace iNKORE.UI.WPF.Modern.Controls.Primitives

--- a/source/iNKORE.UI.WPF.Modern/Controls/Primitives/TitleBarControl.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Primitives/TitleBarControl.cs
@@ -1,25 +1,4 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-using System;
-*/
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Helpers;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-using iNKORE.UI.WPF.Modern.Helpers;
-*/
-using iNKORE.UI.WPF.Modern.Helpers;
+﻿using iNKORE.UI.WPF.Modern.Helpers;
 using iNKORE.UI.WPF.Modern.Helpers.Styles;
 using System;
 using System.Diagnostics;

--- a/source/iNKORE.UI.WPF.Modern/Controls/ScrollInfoAdapter.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/ScrollInfoAdapter.cs
@@ -5,20 +5,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Media.Animation;
-在此之后:
-using System.Windows.Media.Animation;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.ScrollViewer;
-*/
 using System.Windows.Media.Animation;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/ScrollViewerBehavior.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/ScrollViewerBehavior.cs
@@ -4,20 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Controls;
-在此之后:
-using System.Windows.Controls;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.ScrollViewer;
-*/
 using System.Windows.Controls;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/ScrollViewerEx.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/ScrollViewerEx.cs
@@ -1,14 +1,4 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Controls.Helpers;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern.Controls.Helpers;
-*/
-using iNKORE.UI.WPF.Modern.Controls.Helpers;
+﻿using iNKORE.UI.WPF.Modern.Controls.Helpers;
 using iNKORE.UI.WPF.Modern.Controls.Primitives;
 using System;
 using System.Windows;

--- a/source/iNKORE.UI.WPF.Modern/Controls/SymbolIcon.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/SymbolIcon.cs
@@ -1,28 +1,5 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
-using System.Windows;
-*/
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System.Windows.Media;
-在此之后:
-using System.Windows.Media;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls;
-using iNKORE.UI.WPF.Modern.Controls.IconElement;
-*/
 using System.Windows.Media;
 
 namespace iNKORE.UI.WPF.Modern.Controls

--- a/source/iNKORE.UI.WPF.Modern/Controls/TextContextMenu.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/TextContextMenu.cs
@@ -1,19 +1,4 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using iNKORE.UI.WPF.Modern.Controls.Primitives;
-using System.Linq;
-在此之后:
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Controls.Primitives;
-using iNKORE.UI.WPF.Modern.Controls.TextContextMenu;
-using iNKORE.UI.WPF.Modern.Controls.TextContextMenu.TextContextMenu;
-using System.Linq;
-*/
-using iNKORE.UI.WPF.Modern.Common;
+﻿using iNKORE.UI.WPF.Modern.Common;
 using iNKORE.UI.WPF.Modern.Controls.Helpers;
 using System.Linq;
 using System.Windows;

--- a/source/iNKORE.UI.WPF.Modern/Helpers/ColorsHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Helpers/ColorsHelper.cs
@@ -6,18 +6,6 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using Microsoft.Win32;
 using iNKORE.UI.WPF.Modern.Media.ColorPalette;
-
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using Windows.UI.ViewManagement;
-在此之后:
-using Windows.UI.ViewManagement;
-using iNKORE;
-using iNKORE.UI;
-using iNKORE.UI.WPF;
-using iNKORE.UI.WPF.Modern;
-using iNKORE.UI.WPF.Modern.Helpers;
-*/
 using Windows.UI.ViewManagement;
 
 namespace iNKORE.UI.WPF.Modern.Helpers

--- a/source/iNKORE.UI.WPF.Modern/Helpers/Styles/SnapLayout.cs
+++ b/source/iNKORE.UI.WPF.Modern/Helpers/Styles/SnapLayout.cs
@@ -1,12 +1,5 @@
-﻿
-/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.TitleBar;
-using System;
-*/
-using iNKORE.UI.WPF.Modern.Common;
+﻿using iNKORE.UI.WPF.Modern.Common;
+using iNKORE.UI.WPF.Modern.Controls.Primitives;
 using iNKORE.UI.WPF.Modern.Helpers;
 using iNKORE.UI.WPF.Modern.Native;
 using System;
@@ -21,19 +14,11 @@ using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media;
 using static iNKORE.UI.WPF.Modern.Native.User32;
-//using Windows.Win32;
 
 namespace iNKORE.UI.WPF.Modern.Helpers.Styles
 {
     /// <summary>
-
-    /* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-    在此之前:
-        /// Brings the Snap Layout functionality from Windows 11 to a custom <see cref="Controls.TitleBar"/>.
-    在此之后:
-        /// Brings the Snap Layout functionality from Windows 11 to a custom <see cref="TitleBar.TitleBar"/>.
-    */
-    /// Brings the Snap Layout functionality from Windows 11 to a custom <see cref="TitleBar.TitleBar.TitleBar"/>.
+    /// Brings the Snap Layout functionality from Windows 11 to a custom <see cref="TitleBar"/>.
     /// </summary>
     public class SnapLayout
     {

--- a/source/iNKORE.UI.WPF.Modern/Markup/TextContextMenuExtension.cs
+++ b/source/iNKORE.UI.WPF.Modern/Markup/TextContextMenuExtension.cs
@@ -1,12 +1,4 @@
-﻿/* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
-在此之前:
-using System;
-在此之后:
-using iNKORE.UI.WPF.Modern.Controls.TextContextMenu;
-using iNKORE.UI.WPF.Modern.Controls.TextContextMenu.TextContextMenu;
-using System;
-*/
-using iNKORE.UI.WPF.Modern.Controls;
+﻿using iNKORE.UI.WPF.Modern.Controls;
 using System;
 using System.ComponentModel;
 using System.Threading;

--- a/source/iNKORE.UI.WPF.Modern/iNKORE.UI.WPF.Modern.csproj
+++ b/source/iNKORE.UI.WPF.Modern/iNKORE.UI.WPF.Modern.csproj
@@ -12,6 +12,7 @@
 		<AssemblyOriginatorKeyFile>..\..\assets\misc\iNKORE.Pulic.snk</AssemblyOriginatorKeyFile>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/source/iNKORE.UI.WPF.Modern/iNKORE.UI.WPF.Modern.csproj
+++ b/source/iNKORE.UI.WPF.Modern/iNKORE.UI.WPF.Modern.csproj
@@ -11,6 +11,7 @@
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\..\assets\misc\iNKORE.Pulic.snk</AssemblyOriginatorKeyFile>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
* feat: 新增两个Frame的方法重载 *（嗯。原本只有Type类型的重载）*
  * `public bool Navigate(object content, NavigationTransitionInfo infoOverride)`
  * `public bool Navigate(object content, object extraData, NavigationTransitionInfo infoOverride)`
* feat: 增加两个nuget的badge
  ![image](https://github.com/InkoreStudios/UI.WPF.Modern/assets/103164490/6015b7c5-fda2-4def-b0c5-185348a81b68)
* style: 删除无用的注释
  ```diff
  - /* 项目“iNKORE.UI.WPF.Modern (net452)”的未合并的更改
  - 在此之前:
  - using System.Windows;
  - 在此之后:
  - using iNKORE.UI.WPF.Modern.Controls.IconElement;
  - using iNKORE.UI.WPF.Modern.Controls.IconElement.IconElement;
  - using System.Windows;
  - */
  ```
* ci: 使用publish单文件发布`iNKORE.UI.WPF.Modern.Gallery`
